### PR TITLE
I corrected wrong URLs in the contribution guide

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -1,7 +1,7 @@
 ## How to contribute
 
-- [Fork](https://github.com/hitchhicker007/tic_tac_toe/fork) this repository
-- Clone your forked repository to your PC (`git clone "url"`)
+- [Fork](https://github.com/JenilGajjar20/React-imageGallery.git/fork) this repository
+- Clone your forked repository to your PC (`git clone https://github.com/<-your-gitub-username->/React-imageGallery.git`)
 - Create a new branch to add your work (i.e. `git checkout -b your-full-name-branch`)
 - Add your files (`git add .`), commit (`git commit -m "few cool words for your commit message"`) and push (`git push origin your-full-name-branch`)
 - Create a pull request with proper title & explanation 


### PR DESCRIPTION
It appears that some URLs in the contribution guidelines are pointing to another repo and another GitHub account , this can be a misleading factor for open source newbies, I have corrected this perfectly, kindly check and merge this, thanks @JenilGajjar20