### PR TITLE
[Issue-3] Improve Cards Grid responsiveness

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -34,7 +34,7 @@ function App() {
           Loading...
         </h1>
       ) : (
-        <div className="grid grid-cols-3 gap-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {images.map((image) => (
             <ImageCard key={image.id} image={image} />
           ))}

--- a/src/components/ImageCard.jsx
+++ b/src/components/ImageCard.jsx
@@ -4,7 +4,7 @@ const ImageCard = ({ image }) => {
   const tags = image.tags.split(",");
 
   return (
-    <div className="max-w-sm rounded overflow-hidden shadow-lg">
+    <div className="max-w-sm w-11/12 rounded overflow-hidden shadow-lg ml-auto mr-auto sm:w-full">
       <img className="w-full h-80" src={image.webformatURL} alt="..." />
       <div className="px-7 py-4">
         <div className="font-bold text-gray-700 mb-2">


### PR DESCRIPTION
Description - Make Image Cards Grid responsive for all screens: 
Desktop - 
<img width="1424" alt="Screenshot 2022-10-18 at 3 05 28 PM" src="https://user-images.githubusercontent.com/55198441/196396223-cecc6e36-6bd7-4a14-bee6-595883c36c33.png">
Tab - 
<img width="820" alt="Screenshot 2022-10-18 at 3 07 28 PM" src="https://user-images.githubusercontent.com/55198441/196396160-629aae4c-b06e-4aaf-8466-a0877ed711c2.png">
Mobile - 
<img width="543" alt="Screenshot 2022-10-18 at 3 09 03 PM" src="https://user-images.githubusercontent.com/55198441/196396304-d25364b9-5659-4063-8af1-d9678192a302.png">
<img width="358" alt="Screenshot 2022-10-18 at 3 08 16 PM" src="https://user-images.githubusercontent.com/55198441/196396316-293370b0-f2d9-42e1-985c-f8d192e5c970.png">


